### PR TITLE
Fix missing m4sugar.m4 issue

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -42,3 +42,9 @@ zopen_get_version()
 {
   ./src/bison --version | head -1 | awk '{ print $4 }'
 }
+
+zopen_append_to_zoslib_env() {
+cat <<EOF
+BISON_PKGDATADIR|set|PROJECT_ROOT/share/bison
+EOF
+}


### PR DESCRIPTION
Bison attempts to locate m4sugar.m4 using the install directory as specified at build time.  This can be overriden with the BISON_PKGDATADIR environment variable.

Bison is a dependency for bash